### PR TITLE
Changed namespaces of dialogue files to match Dom's namespace naming scheme

### DIFF
--- a/Assets/_app/Scripts/Interactables/Talker.cs
+++ b/Assets/_app/Scripts/Interactables/Talker.cs
@@ -1,8 +1,8 @@
 using System.Collections;
-using Assets._app.Scripts.Managers;
+using _app.Scripts.Managers;
 using UnityEngine;
 
-namespace Assets._app.Scripts.Interactables {
+namespace _app.Scripts.Interactables {
     public class Talker : Interactable {
         [Header("Dialogue Fields")]
         public string speaker;

--- a/Assets/_app/Scripts/Managers/DialogueBoxManager.cs
+++ b/Assets/_app/Scripts/Managers/DialogueBoxManager.cs
@@ -1,7 +1,7 @@
 using TMPro;
 using UnityEngine;
 
-namespace Assets._app.Scripts.Managers {
+namespace _app.Scripts.Managers {
     public class DialogueBoxManager : MonoBehaviour {
         [Header("Singleton Reference")]
         public static DialogueBoxManager Instance { get; private set; }


### PR DESCRIPTION
The scripts I added for the dialogue system used a namespace scheme that started with `Assets._app.Scripts...`, so I changed it to match the other files (`_app.Scripts...`)