### PR TITLE
Added error handling for incorrect dialogue script key

### DIFF
--- a/Assets/Scenes/DialogueTesting.unity
+++ b/Assets/Scenes/DialogueTesting.unity
@@ -312,10 +312,6 @@ MonoBehaviour:
   - Dialogue_RedAmogus_Test1
   - Dialogue_RedAmogus_Test2
   - Dialogue_RedAmogus_Test3
-  dialogueScripts:
-  - dialogues: []
-  - dialogues: []
-  - dialogues: []
 --- !u!136 &260177504
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -532,11 +528,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4474671804661092820, guid: 31141727d65f039439c30b55d6909445, type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4474671804661092820, guid: 31141727d65f039439c30b55d6909445, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4474671804661092820, guid: 31141727d65f039439c30b55d6909445, type: 3}
       propertyPath: m_AnchorMin.y

--- a/Assets/_app/ScriptableObjects/DialogueScripts/DialogueData.asset
+++ b/Assets/_app/ScriptableObjects/DialogueScripts/DialogueData.asset
@@ -114,16 +114,16 @@ MonoBehaviour:
           text: 'Sus? Haha Sussy Baka!
 
             Imposter Among Us!'
-          audioKey: 
+          audioKey: Audio_MsInfo_Amogus
         - speaker: Al
           text: Please, just stop! I'll give you whatever you want!
-          audioKey: 
+          audioKey: Audio_Al_Amogus
         - speaker: Red Amogus
           text: Emergency Meeting!
-          audioKey: 
+          audioKey: Audio_MsInfo_Amogus
     - key: Dialogue_RedAmogus_Test3
       value:
         dialogues:
         - speaker: Red Amogus
           text: '*Red Amogus was ejected.*'
-          audioKey: 
+          audioKey: Audio_MsInfo_Amogus

--- a/Assets/_app/Scripts/Interactables/Talker.cs
+++ b/Assets/_app/Scripts/Interactables/Talker.cs
@@ -11,16 +11,7 @@ namespace _app.Scripts.Interactables {
         [Header("Dialogue Fields")]
         // Dictionary keys of dialogue scripts in DialogueData file
         [SerializeField] private string[] dialogueScriptKeys;
-        [HideInInspector] public DialogueScript[] dialogueScripts;
         private int scriptIndex;
-
-        // ===== Unity Lifecycle Events =====
-
-        public void Start() {
-            // Get dialogue scripts from script keys
-            if (!!DialogueBoxManager.Instance && dialogueScriptKeys.Length != 0)
-                dialogueScripts = DialogueBoxManager.Instance.GetScripts(dialogueScriptKeys);
-        }
 
         // ===== Interactable Overrides =====
 
@@ -32,11 +23,23 @@ namespace _app.Scripts.Interactables {
 
         private IEnumerator DisplayDialogue() {
             // If dialogueScripts empty, end coroutine
-            if (dialogueScripts.Length == 0)
+            if (dialogueScriptKeys.Length == 0)
                 yield break;
 
             // Get current script of dialogue
-            DialogueScript dialogueScript = dialogueScripts[scriptIndex];
+            DialogueScript dialogueScript = null;
+
+            // Get next dialogue script from key
+            if (!!DialogueBoxManager.Instance && dialogueScriptKeys.Length != 0)
+                dialogueScript = DialogueBoxManager.Instance.GetScript(dialogueScriptKeys[scriptIndex]);
+                
+            // Increment script index
+            if (scriptIndex < dialogueScriptKeys.Length - 1)
+                scriptIndex++;
+
+            // If no defined dialogue script was found, exit coroutine
+            if (dialogueScript == null)
+                yield break;
 
             // Disable player
             if (!!InputManager.Instance)
@@ -53,10 +56,6 @@ namespace _app.Scripts.Interactables {
                 yield return new WaitUntil(() => InputManager.Instance.GetInteracting());
             // Display next dialogue in script
             } while (dialogueScript.Next());
-            
-            // Move to next script of dialogue, if applicable
-            if (scriptIndex < dialogueScripts.Length - 1)
-                scriptIndex++;
 
             // Enable player
             if (!!InputManager.Instance)

--- a/Assets/_app/Scripts/Managers/DialogueBoxManager.cs
+++ b/Assets/_app/Scripts/Managers/DialogueBoxManager.cs
@@ -65,17 +65,12 @@ namespace _app.Scripts.Managers {
                 dialogueUI.enabled = false;
         }
 
-        public DialogueScript[] GetScripts(string[] scriptKeys) {
+        public DialogueScript GetScript(string scriptKey) {
             // If dialogue data does not exist, return
             if (!dialogueData)
                 return null;
-            // Create list of dialogue scripts
-            List<DialogueScript> scripts = new List<DialogueScript>();
-            // Get scripts from scriptKeys
-            foreach (string scriptKey in scriptKeys)
-                scripts.Add(dialogueData.GetScript(scriptKey));
             // Return list of scripts, converted to array
-            return scripts.ToArray();
+            return dialogueData.GetScript(scriptKey);
         }
     }
 }

--- a/Assets/_app/Scripts/Operators/ICalculables.meta
+++ b/Assets/_app/Scripts/Operators/ICalculables.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3d825702d9e48834a8b142d60d4eec18
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
### Changes
- Modified Talker and DialogueBoxManager to retrieve individual dialogue scripts from the DialogueData file instead of retrieving them in bulk at the start of the level
- Set Talker to end interaction early if DialogueScript does not exist, and move on to next DialogueScript.